### PR TITLE
Add the has_header option in quicktable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,7 @@ Run the following at the command line:
 Then add the following includes into any module requiring the form
 
 ```erlang
-	-include_lib("sigma_form/include/records.hrl").
+	-include_lib("quicktable/include/records.hrl").
 ```
 
 ## Usage
@@ -37,10 +37,24 @@ Then add the following includes into any module requiring the form
 		data=[
 			["R1C1", "R1C2", "R1C3"],
 			["R2C1", "R2C2", "R2C3"],
-			["R3C1", "R3C2", "R3C3"],
+			["R3C1", "R3C2", "R3C3"]
 		]
 	}.
 ```
+or - enabling interpretation of first row as header:
+
+```erlang
+	#quicktable{
+		html_encode=true,
+		has_header=true,
+		data=[
+			{"tupleR1C1", "tupleR1C2", "tupleR1C3"},
+			{"tupleR2C1", "tupleR2C2", "tupleR2C3"},
+			{"tupleR3C1", "tupleR3C2", "tupleR3C3"}
+		]
+	}.
+```
+
 
 The `data` attribute is a list of rows, with the each row merely being a list
 of cells, and the cell contents being encoded either with the specified

--- a/README.markdown
+++ b/README.markdown
@@ -46,9 +46,9 @@ or - enabling interpretation of first row as header:
 ```erlang
 	#quicktable{
 		html_encode=true,
-		has_header=true,
+		first_row_is_header=true,
 		data=[
-			{"tupleR1C1", "tupleR1C2", "tupleR1C3"},
+			{"HeaderC1", "HeaderC2", "HeaderC3"},
 			{"tupleR2C1", "tupleR2C2", "tupleR2C3"},
 			{"tupleR3C1", "tupleR3C2", "tupleR3C3"}
 		]

--- a/include/records.hrl
+++ b/include/records.hrl
@@ -1,1 +1,1 @@
--record(quicktable, {?ELEMENT_BASE(element_quicktable), data=[], has_header=true, html_encode=true, mode=text}).
+-record(quicktable, {?ELEMENT_BASE(element_quicktable), data=[], first_row_is_header=false, html_encode=true, mode=text}).

--- a/include/records.hrl
+++ b/include/records.hrl
@@ -1,1 +1,1 @@
--record(quicktable, {?ELEMENT_BASE(element_quicktable), data=[], html_encode=true, mode=text}).
+-record(quicktable, {?ELEMENT_BASE(element_quicktable), data=[], has_header=true, html_encode=true, mode=text}).

--- a/src/element_quicktable.erl
+++ b/src/element_quicktable.erl
@@ -1,9 +1,9 @@
--module (element_quicktable).
+-module(element_quicktable).
 -include_lib("nitrogen_core/include/wf.hrl").
 -include("records.hrl").
 -export([
-	reflect/0,
-	render_element/1
+    reflect/0,
+    render_element/1
 ]).
 
 reflect() -> record_info(fields, quicktable).
@@ -23,19 +23,46 @@ reflect() -> record_info(fields, quicktable).
 %% 		{row2_cell1,row2_cell2,row2_cell3},
 %% 		...
 %% 	].
+
 render_element(Rec = #quicktable{}) ->
-	#table{
-		class=Rec#quicktable.class,
-		rows=lists:map(fun(Row) ->
-			Cells = case is_tuple(Row) of
-				true -> tuple_to_list(Row);
-				false -> Row
-			end,
-			#tablerow{cells=lists:map(fun(Cell) ->
-				case Rec#quicktable.mode of
-					body -> #tablecell{body=Cell};
-					text -> #tablecell{text=Cell,html_encode=Rec#quicktable.html_encode}
-				end
-			end,Cells)}
-		end,Rec#quicktable.data)
-	}.
+    Mode = Rec#quicktable.mode,
+    HtmlEncode = Rec#quicktable.html_encode,
+    FirstRowIsHeader = Rec#quicktable.has_header,
+    Data = Rec#quicktable.data,
+
+    case FirstRowIsHeader of
+        true ->
+            [Header | Rows] = Data,
+            HElem = render_row(Header, Mode, HtmlEncode, header),
+            RElems = [render_row(Row, Mode, HtmlEncode, row) || Row <- Rows],
+            #table{
+                header = [HElem],
+                class = Rec#quicktable.class,
+                rows = RElems
+            };
+        false ->
+            AllRElems = [render_row(Row, Mode, HtmlEncode, row) || Row <- Data],
+            #table{
+                class = Rec#quicktable.class,
+                rows = AllRElems
+            }
+    end.
+
+render_row(Row, Mode, HtmlEncode, Type) ->
+    Cells =
+        case is_tuple(Row) of
+            true -> tuple_to_list(Row);
+            false -> Row
+        end,
+    CellData = lists:map(
+        fun(Cell) ->
+            case {Type, Mode} of
+                {row, body} -> #tablecell{body = Cell};
+                {header, body} -> #tableheader{body = Cell};
+                {row, text} -> #tablecell{text = Cell, html_encode = HtmlEncode};
+                {header, text} -> #tableheader{text = Cell, html_encode = HtmlEncode}
+            end
+        end,
+        Cells
+    ),
+    #tablerow{cells = CellData}.

--- a/src/element_quicktable.erl
+++ b/src/element_quicktable.erl
@@ -27,8 +27,9 @@ reflect() -> record_info(fields, quicktable).
 render_element(Rec = #quicktable{}) ->
     Mode = Rec#quicktable.mode,
     HtmlEncode = Rec#quicktable.html_encode,
-    FirstRowIsHeader = Rec#quicktable.has_header,
+    FirstRowIsHeader = Rec#quicktable.first_row_is_header,
     Data = Rec#quicktable.data,
+    Class = Rec#quicktable.class,
 
     case FirstRowIsHeader of
         true ->
@@ -37,13 +38,13 @@ render_element(Rec = #quicktable{}) ->
             RElems = [render_row(Row, Mode, HtmlEncode, row) || Row <- Rows],
             #table{
                 header = [HElem],
-                class = Rec#quicktable.class,
+                class = Class,
                 rows = RElems
             };
         false ->
             AllRElems = [render_row(Row, Mode, HtmlEncode, row) || Row <- Data],
             #table{
-                class = Rec#quicktable.class,
+                class = Class,
                 rows = AllRElems
             }
     end.


### PR DESCRIPTION
The quicktable is extended with an attribute has_header.
In order to not break old behaviour the has_header is false
per default.

The README has been adapted to reflect the new example
and fixes the include-statement.

This probably is a better solution to https://github.com/nitrogen/nitrogen_core/pull/146.
Kind regards, will be out some days.



